### PR TITLE
fix: bump python-dotenv y sqlparse para CVEs activos (SCA)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pluggy==1.6.0
 psycopg2-binary==2.9.11
 pytest==8.3.2
 pytest-django==4.8.0
-python-dotenv==1.2.1
+python-dotenv==1.2.2
 requests==2.32.5
 shortuuid==1.0.13
 sqlparse==0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pytest-django==4.8.0
 python-dotenv==1.2.2
 requests==2.32.5
 shortuuid==1.0.13
-sqlparse==0.5.3
+sqlparse==0.5.4
 stripe==13.2.0
 typing_extensions==4.15.0
 tzdata==2025.2


### PR DESCRIPTION
Promoción a main de los bumps de dependencias verificados contra DefectDojo.

- python-dotenv 1.2.1 -> 1.2.2: CVE-2026-28684 (symlink overwrite)
- sqlparse 0.5.3 -> 0.5.4: GHSA-27jp-wm6q-gp25 (ReDoS)

Ambos findings quedan marcados como Mitigated en DefectDojo (engagement CI - SCA) tras el reimport del nuevo pip-audit.